### PR TITLE
docs: add collaboration guide

### DIFF
--- a/COLLABORATION.md
+++ b/COLLABORATION.md
@@ -1,0 +1,18 @@
+# Collaboration Guide
+
+## How to Contribute
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Submit a pull request
+
+## Code Style
+
+- Follow PEP 8 for Python code
+- Use type hints where possible
+- Write docstrings for all public functions
+
+## Review Process
+
+All PRs require at least one review before merging.


### PR DESCRIPTION
Adding collaboration guidelines for contributors.

Co-authored-by: Sky Mirror <tiankongzhijing888@users.noreply.github.com>